### PR TITLE
remove one useless thread from fridge server

### DIFF
--- a/fridge-server/fridge-server.go
+++ b/fridge-server/fridge-server.go
@@ -5,11 +5,10 @@ var lastEntries []string
 func main() {
 	configPath := "./config.json"
 	fridgeStock, tableHeader := readConfig(configPath)
-	block := make(chan bool)
+	
 	go ShoppingWrapper(fridgeStock)
 	go startUdpServer(fridgeStock)
-	go startHttpServer(fridgeStock, tableHeader)
-	<- block
+	startHttpServer(fridgeStock, tableHeader)
 }
 
 


### PR DESCRIPTION
This fix will greatly improve the performance of the rest of the system as the scheduler doesn't have to count as high to iterate through all running threads.